### PR TITLE
Add note on excluding angle brackets.

### DIFF
--- a/walkthrough/GettinGit.md
+++ b/walkthrough/GettinGit.md
@@ -3,6 +3,9 @@
 ---
 
 # Some Essential Git Concepts
+
+**Note:** Make sure you exclude the angle brackets from your commands. These brackets are there to signal you when a unique input is required. 
+
 ### To create a new git repository
 `$ git init`
 

--- a/walkthrough/gitCribNotes.md
+++ b/walkthrough/gitCribNotes.md
@@ -1,8 +1,10 @@
-# Git/Github Crib Sheet
+# Git/GitHub Crib Sheet
 
 ## Git Repos
 
 Git is version control that allows us to make and track revisions within a directory over time.
+
+**Note:** Make sure you exclude the angle brackets from your commands. These brackets are there to signal you when a unique input is required. 
 
 1) Initiate a directory to be a git *repository*
 


### PR DESCRIPTION
Students often leave in angle brackets unless otherwise specified, as seen in the curriculum pre-work results. I added a note to specify that these brackets should be removed from their git commands. 